### PR TITLE
SLF4J logging feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Build and publish jwiki on your local machine with
 ./gradlew build publishToMavenLocal
 ```
 
+## Logging
+Using the system property: <strong>ColorLogOldMode </strong>from comand line, will be used the normal logging way, without
+will be used SLF4J logging.
+* <strong> -DColorLogOldMode </strong> for normal logging way
+* <strong> -Dlog4j.configuration="file:PATH\OF\FILE\log4j.properties" </strong> for slf4j logging using an external properties file
+
+
 ## Resources
 * [Examples](https://github.com/fastily/jwiki/wiki/Examples)
 * [Javadocs](https://fastily.github.io/jwiki/docs/jwiki/)

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ repositories {
 dependencies {
     api "com.google.code.gson:gson:2.8.5"
     api "com.squareup.okhttp3:okhttp:3.11.0"
+   
+    //slf4j
+    compile group: 'org.slf4j', name:'slf4j-api', version: '1.7.2'
+    compile group: 'org.slf4j', name:'slf4j-log4j12', version: '1.7.25'
     
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'

--- a/src/main/java/fastily/jwiki/core/ColorLog.java
+++ b/src/main/java/fastily/jwiki/core/ColorLog.java
@@ -1,5 +1,8 @@
 package fastily.jwiki.core;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -13,10 +16,25 @@ import java.time.format.DateTimeFormatter;
 class ColorLog
 {
 	/**
+	 * Creating logger
+	 */
+	private static Logger logger = LoggerFactory.getLogger(ColorLog.class);
+	/**
+	 * Properties system, IF DEFINED, logging on standard error; otherwise logging
+	 * with Log4j
+	 */
+	private static final String COLORLOGPROP = "ColorLogOldMode";
+
+	/**
+	 * Flag to use Log4j
+	 */
+	private boolean useLog4j;
+	
+	/**
 	 * The date formatter prefixing output.
 	 */
 	private static final DateTimeFormatter df = DateTimeFormatter.ofPattern("MMM dd, yyyy hh:mm:ss a");
-
+	
 	/**
 	 * Flag indicating whether logging with this object is allowed.
 	 */
@@ -30,6 +48,12 @@ class ColorLog
 	protected ColorLog(boolean enableLogging)
 	{
 		enabled = enableLogging;
+		// If System property is defined, logging output will be used
+		if (System.getProperty(COLORLOGPROP) != null) {
+			useLog4j = false;
+		} else { // True to use Log4j logging
+			useLog4j = true;
+		}
 	}
 
 	/**
@@ -51,10 +75,15 @@ class ColorLog
 	 * 
 	 * @param wiki The wiki object to use
 	 * @param s The String to print.
+	 * @return If logging is enabled can returns warning log using Log4j, otherwise
+	 *         returns logging output
 	 */
 	protected void warn(Wiki wiki, String s)
 	{
-		log(wiki, s, "WARNING", CC.YELLOW);
+		if (useLog4j)
+			logger.warn(wiki + " - " + s);
+		else
+			log(wiki, s, "WARNING", CC.YELLOW);
 	}
 
 	/**
@@ -62,10 +91,15 @@ class ColorLog
 	 * 
 	 * @param wiki The wiki object to use
 	 * @param s The String to print.
+	 * @return if logging is enabled can returns info log using Log4j, otherwise
+	 *         returns logging output
 	 */
 	protected void info(Wiki wiki, String s)
 	{
-		log(wiki, s, "INFO", CC.GREEN);
+		if (useLog4j)
+			logger.info(wiki + " - " + s);
+		else
+			log(wiki, s, "INFO", CC.GREEN);
 	}
 
 	/**
@@ -73,10 +107,15 @@ class ColorLog
 	 * 
 	 * @param wiki The wiki object to use
 	 * @param s The String to print.
+	 * @return If logging is enabled can returns error log using Log4j, otherwise
+	 *         returns logging output
 	 */
 	protected void error(Wiki wiki, String s)
 	{
-		log(wiki, s, "ERROR", CC.RED);
+		if (useLog4j)
+			logger.error(wiki + " - " + s);
+		else
+			log(wiki, s, "ERROR", CC.RED);
 	}
 
 	/**
@@ -84,10 +123,16 @@ class ColorLog
 	 * 
 	 * @param wiki The wiki object to use
 	 * @param s The String to print.
+	 * @return If logging is enabled can returns debug log using Log4j, otherwise
+	 *         returns logging output
 	 */
 	protected void debug(Wiki wiki, String s)
 	{
-		log(wiki, s, "DEBUG", CC.PURPLE);
+		if (useLog4j)
+			logger.debug(wiki + " - " + s);
+		else
+			log(wiki, s, "DEBUG", CC.PURPLE);
+
 	}
 
 	/**
@@ -95,10 +140,15 @@ class ColorLog
 	 * 
 	 * @param wiki The wiki object to use
 	 * @param s The String to print.
+	 * @return If logging is enabled can returns fyi log using Log4j, otherwise
+	 *         returns logging output
 	 */
 	protected void fyi(Wiki wiki, String s)
 	{
-		log(wiki, s, "FYI", CC.CYAN);
+		if (useLog4j)
+			logger.trace(wiki + " - " + s);
+		else
+			log(wiki, s, "FYI", CC.CYAN);
 	}
 
 	/**

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,9 @@
+# Root logger option
+log4j.rootLogger=INFO, DEBUG, file
+
+log4j.appender.file=org.apache.log4j.RollingFileAppender 
+log4j.appender.file.File=log.log
+log4j.appender.file.MaxFileSize=10000KB
+log4j.appender.file.MaxBackupIndex=10
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} [%t] %-5p:: %m%n

--- a/src/test/java/fastily/jwiki/core/ColorLogTests.java
+++ b/src/test/java/fastily/jwiki/core/ColorLogTests.java
@@ -1,0 +1,271 @@
+package fastily.jwiki.core;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+
+public class ColorLogTests {
+
+	private final static ColorLog colorLog = new ColorLog(true);
+	private final Wiki wiki = new Wiki("test.wikipedia.org");
+	private static Logger logger = LoggerFactory.getLogger(ColorLogTests.class);
+
+	/**
+	 * File where to log logging messages
+	 */
+	String filePath = "ColorLogTest.log";
+
+	/**
+	 * Read a file line by line and looks for stringToFind. If not found, return
+	 * false and exit
+	 * 
+	 * @param stringToFind String we want to search
+	 */
+	public static boolean readFileFindString(String filePath, String stringToFind) throws IOException {
+		String currentLine;
+		BufferedReader bReader = null;
+		try {
+			bReader = new BufferedReader(new FileReader(filePath));
+
+			while ((currentLine = bReader.readLine()) != null) {
+				if (currentLine.contains(stringToFind)) {
+					return true;
+				}
+			}
+		} catch (IOException e) {
+			logger.error("File not found");
+		} finally {
+			if (bReader != null) {
+				bReader.close();
+			}
+
+		}
+
+		return false;
+	}
+
+	/**
+	 * Message for each level
+	 */
+	String fyi_msg;
+	String debug_msg;
+	String info_msg;
+	String warn_msg;
+	String error_msg;
+
+	@Rule
+	public final TestName testName = new TestName();
+
+	@Before
+	public void setLogMsg() {
+		String simpleTestName = testName.getMethodName();
+
+		fyi_msg = simpleTestName + "_" + "fyi";
+		debug_msg = simpleTestName + "_" + "debug";
+		info_msg = simpleTestName + "_" + "info";
+		warn_msg = simpleTestName + "_" + "warn";
+		error_msg = simpleTestName + "_" + "error";
+	}
+
+	/**
+	 * Log messages with every logging lvl
+	 */
+	private void logMsg() {
+		colorLog.fyi(wiki, fyi_msg);
+		colorLog.debug(wiki, debug_msg);
+		colorLog.info(wiki, info_msg);
+		colorLog.warn(wiki, warn_msg);
+		colorLog.error(wiki, error_msg);
+	}
+
+	/**
+	 * Method to test which log levels will log in the file .log, with TRACE lvl
+	 * setted.
+	 *
+	 */
+	@Test
+	public void testLvlTrace() throws IOException {
+		Marker traceMarker = MarkerFactory.getMarker("TRACE");
+		logger.error(traceMarker, LoggerFactory.getLogger(ColorLog.class).getName());
+
+		logMsg();
+		assertTrue(readFileFindString(filePath, fyi_msg));
+
+		logMsg();
+		assertTrue(readFileFindString(filePath, debug_msg));
+
+		logMsg();
+		assertTrue(readFileFindString(filePath, info_msg));
+
+		logMsg();
+		assertTrue(readFileFindString(filePath, warn_msg));
+
+		logMsg();
+		assertTrue(readFileFindString(filePath, error_msg));
+	}
+
+	@Test
+	public void testLvlDebug() throws IOException {
+
+		Marker debugMarker = MarkerFactory.getMarker("DEBUG");
+		logger.error(debugMarker, LoggerFactory.getLogger(ColorLog.class).getName());
+
+		logMsg();
+		assertFalse(readFileFindString(filePath, fyi_msg));
+
+		logMsg();
+		assertTrue(readFileFindString(filePath, debug_msg));
+
+		logMsg();
+		assertTrue(readFileFindString(filePath, info_msg));
+
+		logMsg();
+		assertTrue(readFileFindString(filePath, warn_msg));
+
+		logMsg();
+		assertTrue(readFileFindString(filePath, error_msg));
+
+	}
+
+	/**
+	 * Method to test which log levels will log in the file .log, wit INFO lvl
+	 * setted. *h
+	 */
+	@Test
+	public void testLvlInfo() throws IOException {
+		Marker infoMarker = MarkerFactory.getMarker("INFO");
+		logger.error(infoMarker, LoggerFactory.getLogger(ColorLog.class).getName());
+
+		logMsg();
+		assertFalse(readFileFindString(filePath, fyi_msg));
+
+		logMsg();
+		assertFalse(readFileFindString(filePath, debug_msg));
+
+		logMsg();
+		assertTrue(readFileFindString(filePath, info_msg));
+
+		logMsg();
+		assertTrue(readFileFindString(filePath, warn_msg));
+
+		logMsg();
+		assertTrue(readFileFindString(filePath, error_msg));
+
+	}
+
+	/**
+	 * Method to test which log levels will log in the file .log, with WARN lvl
+	 * setted.
+	 *
+	 */
+	@Test
+	public void testLvlWarn() throws IOException {
+		Marker warnMarker = MarkerFactory.getMarker("WARM");
+		logger.error(warnMarker, LoggerFactory.getLogger(ColorLog.class).getName());
+
+		logMsg();
+		assertFalse(readFileFindString(filePath, fyi_msg));
+
+		logMsg();
+		assertFalse(readFileFindString(filePath, debug_msg));
+
+		logMsg();
+		assertFalse(readFileFindString(filePath, info_msg));
+
+		logMsg();
+		assertTrue(readFileFindString(filePath, warn_msg));
+
+		logMsg();
+		assertTrue(readFileFindString(filePath, error_msg));
+	}
+
+	/**
+	 * Method to test which log levels will log in the file .log, with ERROR lvl
+	 * setted.
+	 *
+	 */
+	@Test
+	public void testLvlError() throws IOException {
+		
+		Marker errorMarker = MarkerFactory.getMarker("ERROR");
+    	logger.error(errorMarker,LoggerFactory.getLogger(ColorLog.class).getName());
+
+    	logMsg();
+        assertFalse(readFileFindString(filePath, fyi_msg));
+
+        logMsg();
+        assertFalse(readFileFindString(filePath, debug_msg));
+
+        logMsg();
+        assertFalse(readFileFindString(filePath, info_msg));
+
+        logMsg();
+        assertFalse(readFileFindString(filePath, warn_msg));
+
+        logMsg();
+        assertTrue(readFileFindString(filePath, error_msg));
+	}
+
+	/**
+	 * Method to test which log levels will log in the file .log, with FATAL lvl
+	 * setted.
+	 *
+	 */
+	public void testLvlFatal() throws IOException {
+		Marker fatalMarker = MarkerFactory.getMarker("FATAL");
+    	logger.error(fatalMarker,LoggerFactory.getLogger(ColorLog.class).getName());
+		
+        logMsg();
+        assertFalse(readFileFindString(filePath, fyi_msg));
+
+        logMsg();
+        assertFalse(readFileFindString(filePath, debug_msg));
+
+        logMsg();
+        assertFalse(readFileFindString(filePath, info_msg));
+
+        logMsg();
+        assertFalse(readFileFindString(filePath, warn_msg));
+
+        logMsg();
+        assertTrue(readFileFindString(filePath, error_msg));
+	}
+
+	/**
+	 * Method to test which log levels will log in the file .log, with ALL lvl
+	 * setted.
+	 *
+	 */
+	public void testLvlAll() throws IOException {
+			
+		Marker allMarker = MarkerFactory.getMarker("ALL");
+    	logger.error(allMarker,LoggerFactory.getLogger(ColorLog.class).getName());
+
+        logMsg();
+        assertTrue(readFileFindString(filePath, fyi_msg));
+
+        logMsg();
+        assertTrue(readFileFindString(filePath, debug_msg));
+
+        logMsg();
+        assertTrue(readFileFindString(filePath, info_msg));
+
+        logMsg();
+        assertTrue(readFileFindString(filePath, warn_msg));
+
+        logMsg();
+        assertTrue(readFileFindString(filePath, error_msg));
+	}
+}


### PR DESCRIPTION
* added slf4j dependecies in the build.gradle file. Latest version of:
	- slf4j-api
	- slf4j-log4j12
* added ColorLogOldMode system property to switch from normal log to SLF4J logging.
  If ColorLogOldMode is set as parameter from command line,will be used the normal way to logging,
  else slf4j logging. 
* added test
@fcammisa